### PR TITLE
Enhance ExoPlayer activity with playlist and speed control

### DIFF
--- a/app/src/main/res/layout/activity_exoplayer.xml
+++ b/app/src/main/res/layout/activity_exoplayer.xml
@@ -35,4 +35,32 @@
         android:layout_margin="16dp"
         android:background="@android:color/transparent"
         android:src="@android:drawable/ic_menu_always_landscape_portrait" />
+
+    <ImageButton
+        android:id="@+id/btn_prev"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="16dp"
+        android:background="@android:color/transparent"
+        android:src="@android:drawable/ic_media_previous" />
+
+    <ImageButton
+        android:id="@+id/btn_speed"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginBottom="16dp"
+        android:background="@android:color/transparent"
+        android:src="@android:drawable/ic_popup_sync" />
+
+    <ImageButton
+        android:id="@+id/btn_next"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="80dp"
+        android:layout_marginBottom="16dp"
+        android:background="@android:color/transparent"
+        android:src="@android:drawable/ic_media_next" />
 </FrameLayout>


### PR DESCRIPTION
## Summary
- add previous/next/speed buttons to `activity_exoplayer.xml`
- implement playlist support and playback speed cycling in `ExoPlayerActivity`
- auto advance to next item when playback ends

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e9826f9b88328ad0528e7874b8816