### PR TITLE
Add overlay for 10s seek gestures

### DIFF
--- a/app/src/main/java/com/mylocalmanga/app/ExoPlayerActivity.java
+++ b/app/src/main/java/com/mylocalmanga/app/ExoPlayerActivity.java
@@ -23,8 +23,14 @@ public class ExoPlayerActivity extends AppCompatActivity {
     private ExoPlayer player;
     private PlayerView playerView;
     private ImageButton btnClose, btnRotate, btnRatio;
+    private View overlayRewind, overlayForward;
     private boolean isZoomed = false; // track chế độ fit/zoom
     private GestureDetector gestureDetector;
+
+    private void showOverlay(View v) {
+        v.setVisibility(View.VISIBLE);
+        v.postDelayed(() -> v.setVisibility(View.GONE), 500);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,6 +53,8 @@ public class ExoPlayerActivity extends AppCompatActivity {
         btnClose = findViewById(R.id.btn_close);
         btnRotate = findViewById(R.id.btn_rotate);
         btnRatio = findViewById(R.id.btn_ratio);
+        overlayRewind = findViewById(R.id.overlay_rewind);
+        overlayForward = findViewById(R.id.overlay_forward);
 
         // ✅ Nhận dữ liệu từ Intent
         Intent intent = getIntent();
@@ -126,6 +134,7 @@ public class ExoPlayerActivity extends AppCompatActivity {
                     if (pos < 0) {
                         pos = 0;
                     }
+                    showOverlay(overlayRewind);
                 } else {
                     // Fast forward 10 seconds
                     pos = player.getCurrentPosition() + 10000;
@@ -133,6 +142,7 @@ public class ExoPlayerActivity extends AppCompatActivity {
                     if (dur != C.TIME_UNSET) {
                         pos = Math.min(pos, dur);
                     }
+                    showOverlay(overlayForward);
                 }
                 player.seekTo(pos);
                 return true;

--- a/app/src/main/res/layout/activity_exoplayer.xml
+++ b/app/src/main/res/layout/activity_exoplayer.xml
@@ -9,6 +9,56 @@
         android:layout_height="match_parent"
         android:keepScreenOn="true" />
 
+    <!-- Overlay khi tua lùi -->
+    <LinearLayout
+        android:id="@+id/overlay_rewind"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_gravity="center_vertical|start"
+        android:layout_margin="16dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@android:drawable/ic_media_rew"
+            android:tint="@android:color/white" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="10s"
+            android:textColor="@android:color/white"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <!-- Overlay khi tua nhanh -->
+    <LinearLayout
+        android:id="@+id/overlay_forward"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_gravity="center_vertical|end"
+        android:layout_margin="16dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@android:drawable/ic_media_ff"
+            android:tint="@android:color/white" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="10s"
+            android:textColor="@android:color/white"
+            android:textStyle="bold" />
+    </LinearLayout>
+
     <ImageButton
         android:id="@+id/btn_close"
         android:layout_width="48dp"


### PR DESCRIPTION
## Summary
- add overlay layouts for skip forward/back gestures
- show overlays when double tapping during playback

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e980f968c832891d966d07828ecaa