### PR TITLE
Implement offline reading mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,11 @@
             android:screenOrientation="sensorLandscape"
             android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
+        <activity
+            android:name=".OfflineActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/mylocalmanga/app/OfflineActivity.java
+++ b/app/src/main/java/com/mylocalmanga/app/OfflineActivity.java
@@ -1,0 +1,86 @@
+package com.mylocalmanga.app;
+
+import android.os.Bundle;
+import android.content.Intent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OfflineActivity extends AppCompatActivity {
+    private RecyclerView recyclerView;
+    private ImageButton switchBtn;
+    private OfflineAdapter adapter;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_offline);
+
+        recyclerView = findViewById(R.id.recyclerView);
+        switchBtn = findViewById(R.id.btn_switch);
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        adapter = new OfflineAdapter(loadImages());
+        recyclerView.setAdapter(adapter);
+
+        switchBtn.setOnClickListener(v -> {
+            // Close offline and return to main
+            finish();
+        });
+    }
+
+    private List<File> loadImages() {
+        File dir = new File(getExternalFilesDir(null), "offline");
+        List<File> list = new ArrayList<>();
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    if (f.isFile()) list.add(f);
+                }
+            }
+        }
+        return list;
+    }
+
+    private static class OfflineAdapter extends RecyclerView.Adapter<OfflineViewHolder> {
+        private final List<File> files;
+        OfflineAdapter(List<File> f) { files = f; }
+        @Override public OfflineViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View v = View.inflate(parent.getContext(), R.layout.list_item_offline_image, null);
+            return new OfflineViewHolder(v);
+        }
+        @Override public void onBindViewHolder(OfflineViewHolder holder, int position) {
+            File f = files.get(position);
+            Glide.with(holder.img.getContext()).load(f).into(holder.img);
+            holder.itemView.setOnClickListener(v -> {
+                // open MainActivity to view at original page
+                Intent intent = new Intent(v.getContext(), MainActivity.class);
+                intent.putExtra("offlineFile", f.getAbsolutePath());
+                v.getContext().startActivity(intent);
+            });
+        }
+        @Override public int getItemCount() { return files.size(); }
+    }
+
+    private static class OfflineViewHolder extends RecyclerView.ViewHolder {
+        android.widget.ImageView img;
+        OfflineViewHolder(View item) {
+            super(item);
+            img = item.findViewById(R.id.imageView);
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_offline.xml
+++ b/app/src/main/res/layout/activity_offline.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <ImageButton
+        android:id="@+id/btn_switch"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="top|end"
+        android:layout_margin="16dp"
+        android:background="@android:color/transparent"
+        android:src="@android:drawable/ic_menu_manage" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/list_item_offline_image.xml
+++ b/app/src/main/res/layout/list_item_offline_image.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true" />
+
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add an `OfflineActivity` to display downloaded pages
- show offline/online controls in `MainActivity`
- inject a JavaScript button to fetch all images for offline use
- handle image downloads and open local files
- register `OfflineActivity` and layouts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ffca497b483288a7ec726f8499cc7